### PR TITLE
remove password and image right fields from admin edit user form

### DIFF
--- a/app/views/admin/users/_form_edit.html.erb
+++ b/app/views/admin/users/_form_edit.html.erb
@@ -1,0 +1,83 @@
+<%= form_with(model: user, local: true, url: url) do |form| %>
+  <% if user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this member from being saved:</h2>
+
+      <ul>
+      <% user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= form.label :email %>
+    <%= form.email_field :email, autocomplete: "email", required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :first_name %>
+    <%= form.text_field :first_name, autofocus: true, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :last_name %>
+    <%= form.text_field :last_name, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :birthdate %>
+    <%= form.date_field :birthdate, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :phone_number %>
+    <%= form.telephone_field :phone_number, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :address %>
+    <%= form.text_field :address, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :zip_code %>
+    <%= form.text_field :zip_code, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :city %>
+    <%= form.text_field :city, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :country %>
+    <%= form.text_field :country, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :contact_name %>
+    <%= form.text_field :contact_name, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :contact_phone_number %>
+    <%= form.telephone_field :contact_phone_number, required: true, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :contact_relationship %><br />
+    <%= form.collection_select(:contact_relationship, User::CONTACTS, :to_s, :to_s, { include_blank: true }, required: true, class: "form-control") %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :avatar %>
+    <%= form.file_field :avatar, required: true %>
+  </div>
+
+  <div class="actions d-flex mb-3">
+    <%= link_to t('defaults.back'), :back, class: 'btn btn-default btn-lg flex-fill' %>
+    <%= form.submit t('defaults.save'), class: 'btn btn-dark btn-lg flex-fill' %>
+  </div>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -3,6 +3,6 @@
 
 <div class="row">
   <div class="col-md-6 offset-md-3">
-    <%= render 'form', user: @user, url: admin_user_path(@user.id) %>
+    <%= render 'form_edit', user: @user, url: admin_user_path(@user.id) %>
   </div>
 </div>


### PR DESCRIPTION
This PR closes #115 

I removed the password field form the form partial '_form.html.erb'. As this partial was used elsewhere, I could not modify the original one. The simplest solution was to create a new one '_form_edit.html.erb', with almost the same content, to be rendered only on the edit view. I know it makes a lot of similar code, and I will be glad to learn how to refactor it!

I also know I should ask before, but I also removed the 'droit a l'immage' field, because I understand that it is not up to the admin to choose if someone is going to agree or not to the image right. This choice belongs to the user and he/she makes the option allowing or not when subscribing. If you think this field should stay, I will put it back.  

=)