### PR TITLE
add instructions to the subscription confirmation mail

### DIFF
--- a/app/views/subscription_mailer/confirm_subscription.html.erb
+++ b/app/views/subscription_mailer/confirm_subscription.html.erb
@@ -29,7 +29,7 @@
     <strong style="color:red;">moins d'un mois</strong>,
   </li>
   <li>
-    Le règlement de la cotisation (chèque à l'ordre de Parkour Paris ou en espèces,
+    Le règlement de la cotisation (chèque à l'ordre de Parkour Paris ou en espèces)
   </li>
   <li>
     Vous avez également la possibilité de payer en ligne ainsi que de compléter votre dossier directement sur <a href="https://inscriptions.parkourparis.fr/users/sign_in" target="_blank">votre espace Parkour Paris</a> en chargeant une copie numérique de votre certificat médical et de votre formulaire signé.

--- a/app/views/subscription_mailer/confirm_subscription.html.erb
+++ b/app/views/subscription_mailer/confirm_subscription.html.erb
@@ -40,7 +40,7 @@
 </ul>
 
 <p>
-  Si vous optiez pour rendre votre formulaire imprimé, a fin de nous faciliter le contrôle des pièces et gagner du temps lors de la récupération, merci de le mettre dans
+  Si vous préférez imprimer votre dossier, afin de nous faciliter le contrôle des pièces et gagner du temps lors de la récupération, merci de joindre l'ensemble des pièces (formulaire signé, paiement par chèques/espèces, certificat médical à jour) dans
   <strong style="color:red;">une pochette plastique perforée</strong>
   au format A4 comme suit :
 

--- a/app/views/subscription_mailer/confirm_subscription.html.erb
+++ b/app/views/subscription_mailer/confirm_subscription.html.erb
@@ -32,12 +32,15 @@
     Le règlement de la cotisation (chèque à l'ordre de Parkour Paris ou en espèces,
   </li>
   <li>
+    Vous avez également la possibilité de payer en ligne ainsi que de compléter votre dossier directement sur <a href="https://inscriptions.parkourparis.fr/users/sign_in" target="_blank">votre espace Parkour Paris</a> en chargeant une copie numérique de votre certificat médical et de votre formulaire signé.
+  </li>
+  <li>
     Les mineurs doivent faire signer le formulaire par leur représentant légal (père, mère ou tuteur).
   </li>
 </ul>
 
 <p>
-  Afin de nous faciliter le contrôle des pièces et gagner du temps lors de la récupération, merci de mettre votre dossier dans
+  Si vous optiez pour rendre votre formulaire imprimé, a fin de nous faciliter le contrôle des pièces et gagner du temps lors de la récupération, merci de le mettre dans
   <strong style="color:red;">une pochette plastique perforée</strong>
   au format A4 comme suit :
 


### PR DESCRIPTION
This PR closes #114 

I am a rebel, so I totally disobeyed your instructions here!
Instead, I presented the new payment option right after the this paragraph list item:
'Le règlement de la cotisation (chèque à l'ordre de Parkour Paris ou en espèces,'
because I think it will make more sense, knowing that people normally stop reading after finding some payment instructions. 
I also added some other text to present the printed format as an option:
'**Si vous optiez pour rendre votre formulaire imprimé,** a fin de nous faciliter le contrôle des pièces et gagner du temps lors de la récupération, merci de le mettre dans une pochette plastique perforée au format A4 comme suit : '
But if you do not agree, I will follow your instructions.
 =P