### PR TITLE
Fix #492: Update subscription forms when member info changes

### DIFF
--- a/app/models/concerns/members/subscription_form.rb
+++ b/app/models/concerns/members/subscription_form.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Members
+  module SubscriptionForm
+    extend ActiveSupport::Concern
+
+    RELEVANT_ATTRIBUTES = %w[
+      first_name
+      last_name
+      birthdate
+      contact_name
+      contact_phone_number
+      contact_relationship
+    ].freeze
+
+    included do
+      after_update :clear_subscription_forms, if: :relevant_attributes_changed?
+    end
+
+    private
+
+    def clear_subscription_forms
+      subscriptions.with_attached_form.find_each do |subscription|
+        subscription.form.purge if subscription.form.attached?
+      end
+    end
+
+    def relevant_attributes_changed?
+      RELEVANT_ATTRIBUTES.any? { |attr| send("saved_change_to_#{attr}?") }
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -92,7 +92,7 @@ class Member < ApplicationRecord
                   saved_change_to_contact_relationship?
 
     subscriptions.with_attached_form.find_each do |subscription|
-      subscription.form.purge
+      subscription.form.purge if subscription.form.attached?
     end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -49,8 +49,6 @@ class Member < ApplicationRecord
   delegate :email, :phone_number, :address, :zip_code, :city, :country, :full_address,
            to: :user
 
-  after_update :clear_subscription_forms, if: :relevant_attributes_changed?
-
   normalizes :first_name, with: ->(first_name) { first_name.strip.downcase.titleize }
   normalizes :last_name, with: ->(last_name) { last_name.strip.downcase.titleize }
 
@@ -80,17 +78,5 @@ class Member < ApplicationRecord
     return false if camps.include?(camp)
 
     true
-  end
-
-  private
-
-  def clear_subscription_forms
-    subscriptions.with_attached_form.find_each do |subscription|
-      subscription.form.purge if subscription.form.attached?
-    end
-  end
-
-  def relevant_attributes_changed?
-    RELEVANT_ATTRIBUTES.any? { |attr| send("saved_change_to_#{attr}?") }
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -91,8 +91,8 @@ class Member < ApplicationRecord
                   saved_change_to_contact_phone_number? ||
                   saved_change_to_contact_relationship?
 
-    subscriptions.where.not(form: nil).find_each do |subscription|
-      subscription.form.purge if subscription.form.attached?
+    subscriptions.with_attached_form.find_each do |subscription|
+      subscription.form.purge
     end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -48,6 +48,8 @@ class Member < ApplicationRecord
   delegate :email, :phone_number, :address, :zip_code, :city, :country, :full_address,
            to: :user
 
+  after_update :clear_subscription_forms
+
   normalizes :first_name, with: ->(first_name) { first_name.strip.downcase.titleize }
   normalizes :last_name, with: ->(last_name) { last_name.strip.downcase.titleize }
 
@@ -77,5 +79,20 @@ class Member < ApplicationRecord
     return false if camps.include?(camp)
 
     true
+  end
+
+  private
+
+  def clear_subscription_forms
+    return unless saved_change_to_first_name? ||
+                  saved_change_to_last_name? ||
+                  saved_change_to_birthdate? ||
+                  saved_change_to_contact_name? ||
+                  saved_change_to_contact_phone_number? ||
+                  saved_change_to_contact_relationship?
+
+    subscriptions.where.not(form: nil).find_each do |subscription|
+      subscription.form.purge if subscription.form.attached?
+    end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -83,6 +83,15 @@ class Member < ApplicationRecord
 
   private
 
+  RELEVANT_ATTRIBUTES = %w[
+    first_name
+    last_name
+    birthdate
+    contact_name
+    contact_phone_number
+    contact_relationship
+  ].freeze
+
   def clear_subscription_forms
     return unless relevant_attributes_changed?
 
@@ -92,11 +101,6 @@ class Member < ApplicationRecord
   end
 
   def relevant_attributes_changed?
-    saved_change_to_first_name? ||
-      saved_change_to_last_name? ||
-      saved_change_to_birthdate? ||
-      saved_change_to_contact_name? ||
-      saved_change_to_contact_phone_number? ||
-      saved_change_to_contact_relationship?
+    RELEVANT_ATTRIBUTES.any? { |attr| send("saved_change_to_#{attr}?") }
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -81,8 +81,6 @@ class Member < ApplicationRecord
     true
   end
 
-  private
-
   RELEVANT_ATTRIBUTES = %w[
     first_name
     last_name
@@ -91,6 +89,8 @@ class Member < ApplicationRecord
     contact_phone_number
     contact_relationship
   ].freeze
+
+  private
 
   def clear_subscription_forms
     return unless relevant_attributes_changed?

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -84,15 +84,19 @@ class Member < ApplicationRecord
   private
 
   def clear_subscription_forms
-    return unless saved_change_to_first_name? ||
-                  saved_change_to_last_name? ||
-                  saved_change_to_birthdate? ||
-                  saved_change_to_contact_name? ||
-                  saved_change_to_contact_phone_number? ||
-                  saved_change_to_contact_relationship?
+    return unless relevant_attributes_changed?
 
     subscriptions.with_attached_form.find_each do |subscription|
       subscription.form.purge if subscription.form.attached?
     end
+  end
+
+  def relevant_attributes_changed?
+    saved_change_to_first_name? ||
+      saved_change_to_last_name? ||
+      saved_change_to_birthdate? ||
+      saved_change_to_contact_name? ||
+      saved_change_to_contact_phone_number? ||
+      saved_change_to_contact_relationship?
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -4,6 +4,7 @@ class Member < ApplicationRecord
   include ConditionalPagination
   include Members::Available
   include Members::Searchable
+  include Members::SubscriptionForm
 
   MAJORITY_AGE = 18
 
@@ -48,7 +49,7 @@ class Member < ApplicationRecord
   delegate :email, :phone_number, :address, :zip_code, :city, :country, :full_address,
            to: :user
 
-  after_update :clear_subscription_forms
+  after_update :clear_subscription_forms, if: :relevant_attributes_changed?
 
   normalizes :first_name, with: ->(first_name) { first_name.strip.downcase.titleize }
   normalizes :last_name, with: ->(last_name) { last_name.strip.downcase.titleize }
@@ -81,20 +82,9 @@ class Member < ApplicationRecord
     true
   end
 
-  RELEVANT_ATTRIBUTES = %w[
-    first_name
-    last_name
-    birthdate
-    contact_name
-    contact_phone_number
-    contact_relationship
-  ].freeze
-
   private
 
   def clear_subscription_forms
-    return unless relevant_attributes_changed?
-
     subscriptions.with_attached_form.find_each do |subscription|
       subscription.form.purge if subscription.form.attached?
     end

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -18,44 +18,50 @@ describe Member, type: :model do
 
     context 'when member first_name is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(first_name: 'NewName') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(first_name: 'NewName')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member last_name is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(last_name: 'NewLastName') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(last_name: 'NewLastName')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member birthdate is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(birthdate: 10.years.ago) }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(birthdate: 10.years.ago)
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member contact_name is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(contact_name: 'New Contact') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(contact_name: 'New Contact')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member contact_phone_number is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(contact_phone_number: '+33600000000') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(contact_phone_number: '+33600000000')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member contact_relationship is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(contact_relationship: 'Autre') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(contact_relationship: 'Autre')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member attributes not affecting form are updated' do
       it 'does not clear the subscription form' do
-        expect { member.update!(agreed_to_advertising_right: !member.agreed_to_advertising_right) }
-          .not_to(change { subscription.form.attached? })
+        member.update!(agreed_to_advertising_right: !member.agreed_to_advertising_right)
+        expect(subscription.reload.form.attached?).to be true
       end
     end
 
@@ -72,8 +78,8 @@ describe Member, type: :model do
 
       it 'clears all subscription forms' do
         member.update!(first_name: 'NewName')
-        expect(subscription.form.attached?).to be false
-        expect(subscription2.form.attached?).to be false
+        expect(subscription.reload.form.attached?).to be false
+        expect(subscription2.reload.form.attached?).to be false
       end
     end
   end

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -14,6 +14,7 @@ describe Member, type: :model do
         filename: 'form.pdf',
         content_type: 'application/pdf'
       )
+      subscription.reload
     end
 
     context 'when member first_name is updated' do

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -7,6 +7,7 @@ describe Member, type: :model do
     let(:user) { create(:user) }
     let(:member) { create(:member, user: user) }
     let(:category) { create(:category) }
+    let!(:pricing) { create(:pricing, category: category) }
     let(:course) { create(:course, category: category) }
     let(:subscription) { create(:subscription, member: member, status: :confirmed, courses: [course]) }
 

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Member, type: :model do
+  describe '#clear_subscription_forms' do
+    let(:user) { create(:user) }
+    let(:member) { create(:member, user: user) }
+    let(:subscription) { create(:subscription, member: member, status: :confirmed) }
+
+    before do
+      subscription.form.attach(
+        io: StringIO.new('dummy pdf content'),
+        filename: 'form.pdf',
+        content_type: 'application/pdf'
+      )
+    end
+
+    context 'when member first_name is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(first_name: 'NewName') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member last_name is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(last_name: 'NewLastName') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member birthdate is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(birthdate: 10.years.ago) }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member contact_name is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(contact_name: 'New Contact') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member contact_phone_number is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(contact_phone_number: '+33600000000') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member contact_relationship is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(contact_relationship: 'Autre') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member attributes not affecting form are updated' do
+      it 'does not clear the subscription form' do
+        expect { member.update!(agreed_to_advertising_right: !member.agreed_to_advertising_right) }
+          .not_to(change { subscription.form.attached? })
+      end
+    end
+
+    context 'when member has multiple subscriptions' do
+      let(:subscription2) { create(:subscription, member: member, status: :confirmed) }
+
+      before do
+        subscription2.form.attach(
+          io: StringIO.new('dummy pdf content 2'),
+          filename: 'form2.pdf',
+          content_type: 'application/pdf'
+        )
+      end
+
+      it 'clears all subscription forms' do
+        member.update!(first_name: 'NewName')
+        expect(subscription.form.attached?).to be false
+        expect(subscription2.form.attached?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Members::SubscriptionForm do
   let(:member) { create(:member) }
-  let(:subscription) { create(:subscription, member:) }
+  let(:category) { create(:category) }
+  let!(:pricing) { create(:pricing, category:) }
+  let(:course) { create(:course, category:) }
+  let(:subscription) { create(:subscription, member:, courses: [course], status: :confirmed) }
 
   describe '#clear_subscription_forms' do
     before do
@@ -62,7 +65,8 @@ RSpec.describe Members::SubscriptionForm do
     end
 
     context 'when multiple subscriptions have forms' do
-      let(:subscription2) { create(:subscription, member:) }
+      let(:course2) { create(:course, category:, weekday: :tuesday) }
+      let(:subscription2) { create(:subscription, member:, courses: [course2], status: :confirmed, year: subscription.year - 1) }
 
       before do
         subscription2.form.attach(

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -6,7 +6,9 @@ describe Member, type: :model do
   describe '#clear_subscription_forms' do
     let(:user) { create(:user) }
     let(:member) { create(:member, user: user) }
-    let(:subscription) { create(:subscription, member: member, status: :confirmed) }
+    let(:category) { create(:category) }
+    let(:course) { create(:course, category: category) }
+    let(:subscription) { create(:subscription, member: member, status: :confirmed, courses: [course]) }
 
     before do
       subscription.form.attach(
@@ -67,7 +69,8 @@ describe Member, type: :model do
     end
 
     context 'when member has multiple subscriptions' do
-      let(:subscription2) { create(:subscription, member: member, status: :confirmed) }
+      let(:course2) { create(:course, category: category, weekday: Course.weekdays.keys.last) }
+      let(:subscription2) { create(:subscription, member: member, status: :confirmed, courses: [course2]) }
 
       before do
         subscription2.form.attach(
@@ -75,6 +78,7 @@ describe Member, type: :model do
           filename: 'form2.pdf',
           content_type: 'application/pdf'
         )
+        subscription2.reload
       end
 
       it 'clears all subscription forms' do

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -2,15 +2,11 @@
 
 require 'rails_helper'
 
-describe Member, type: :model do
-  describe '#clear_subscription_forms' do
-    let(:user) { create(:user) }
-    let(:member) { create(:member, user: user) }
-    let(:category) { create(:category) }
-    let!(:pricing) { create(:pricing, category: category) }
-    let(:course) { create(:course, category: category) }
-    let(:subscription) { create(:subscription, member: member, status: :confirmed, courses: [course]) }
+RSpec.describe Members::SubscriptionForm do
+  let(:member) { create(:member) }
+  let(:subscription) { create(:subscription, member:) }
 
+  describe '#clear_subscription_forms' do
     before do
       subscription.form.attach(
         io: StringIO.new('dummy pdf content'),
@@ -20,58 +16,53 @@ describe Member, type: :model do
       subscription.reload
     end
 
-    context 'when member first_name is updated' do
-      it 'clears the subscription form' do
-        member.update!(first_name: 'NewName')
-        expect(subscription.reload.form.attached?).to be false
+    context 'when relevant attributes change' do
+      it 'clears attached form when first_name changes' do
+        expect { member.update!(first_name: 'NewName') }
+          .to change { subscription.reload.form.attached? }.from(true).to(false)
+      end
+
+      it 'clears attached form when last_name changes' do
+        expect { member.update!(last_name: 'NewName') }
+          .to change { subscription.reload.form.attached? }.from(true).to(false)
+      end
+
+      it 'clears attached form when birthdate changes' do
+        expect { member.update!(birthdate: 5.years.ago.to_date) }
+          .to change { subscription.reload.form.attached? }.from(true).to(false)
+      end
+
+      it 'clears attached form when contact_name changes' do
+        expect { member.update!(contact_name: 'New Contact') }
+          .to change { subscription.reload.form.attached? }.from(true).to(false)
+      end
+
+      it 'clears attached form when contact_phone_number changes' do
+        expect { member.update!(contact_phone_number: '06 12 34 56 78') }
+          .to change { subscription.reload.form.attached? }.from(true).to(false)
+      end
+
+      it 'clears attached form when contact_relationship changes' do
+        expect { member.update!(contact_relationship: 'Mère') }
+          .to change { subscription.reload.form.attached? }.from(true).to(false)
       end
     end
 
-    context 'when member last_name is updated' do
-      it 'clears the subscription form' do
-        member.update!(last_name: 'NewLastName')
-        expect(subscription.reload.form.attached?).to be false
+    context 'when irrelevant attributes change' do
+      it 'does not clear form when level changes' do
+        expect { member.update!(level: :yellow) }
+          .not_to change { subscription.reload.form.attached? }
+      end
+
+      it 'does not clear form when avatar changes' do
+        new_avatar = fixture_file_upload('avatar.jpg', 'image/jpeg')
+        expect { member.update!(avatar: new_avatar) }
+          .not_to change { subscription.reload.form.attached? }
       end
     end
 
-    context 'when member birthdate is updated' do
-      it 'clears the subscription form' do
-        member.update!(birthdate: 10.years.ago)
-        expect(subscription.reload.form.attached?).to be false
-      end
-    end
-
-    context 'when member contact_name is updated' do
-      it 'clears the subscription form' do
-        member.update!(contact_name: 'New Contact')
-        expect(subscription.reload.form.attached?).to be false
-      end
-    end
-
-    context 'when member contact_phone_number is updated' do
-      it 'clears the subscription form' do
-        member.update!(contact_phone_number: '+33600000000')
-        expect(subscription.reload.form.attached?).to be false
-      end
-    end
-
-    context 'when member contact_relationship is updated' do
-      it 'clears the subscription form' do
-        member.update!(contact_relationship: 'Autre')
-        expect(subscription.reload.form.attached?).to be false
-      end
-    end
-
-    context 'when member attributes not affecting form are updated' do
-      it 'does not clear the subscription form' do
-        member.update!(agreed_to_advertising_right: !member.agreed_to_advertising_right)
-        expect(subscription.reload.form.attached?).to be true
-      end
-    end
-
-    context 'when member has multiple subscriptions' do
-      let(:course2) { create(:course, category: category, weekday: Course.weekdays.keys.last) }
-      let(:subscription2) { create(:subscription, member: member, status: :confirmed, courses: [course2], year: Subscription.current_year - 1) }
+    context 'when multiple subscriptions have forms' do
+      let(:subscription2) { create(:subscription, member:) }
 
       before do
         subscription2.form.attach(
@@ -82,11 +73,25 @@ describe Member, type: :model do
         subscription2.reload
       end
 
-      it 'clears all subscription forms' do
+      it 'clears all attached forms' do
         member.update!(first_name: 'NewName')
+
         expect(subscription.reload.form.attached?).to be false
         expect(subscription2.reload.form.attached?).to be false
       end
+    end
+  end
+
+  describe 'RELEVANT_ATTRIBUTES constant' do
+    it 'contains the expected attributes' do
+      expect(described_class::RELEVANT_ATTRIBUTES).to eq(%w[
+        first_name
+        last_name
+        birthdate
+        contact_name
+        contact_phone_number
+        contact_relationship
+      ])
     end
   end
 end

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe Members::SubscriptionForm do
       end
 
       it 'does not clear form when avatar changes' do
-        new_avatar = fixture_file_upload('avatar.jpg', 'image/jpeg')
+        new_avatar = Rack::Test::UploadedFile.new(Rails.root.join('spec/support/file_examples/avatar.jpg'))
         expect { member.update!(avatar: new_avatar) }
           .not_to change { subscription.reload.form.attached? }
       end
     end
 
     context 'when multiple subscriptions have forms' do
-      let(:course2) { create(:course, category:, weekday: :tuesday) }
+      let(:course2) { create(:course, category:, weekday: :mardi) }
       let(:subscription2) { create(:subscription, member:, courses: [course2], status: :confirmed, year: subscription.year - 1) }
 
       before do

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -71,7 +71,7 @@ describe Member, type: :model do
 
     context 'when member has multiple subscriptions' do
       let(:course2) { create(:course, category: category, weekday: Course.weekdays.keys.last) }
-      let(:subscription2) { create(:subscription, member: member, status: :confirmed, courses: [course2]) }
+      let(:subscription2) { create(:subscription, member: member, status: :confirmed, courses: [course2], year: Subscription.current_year - 1) }
 
       before do
         subscription2.form.attach(


### PR DESCRIPTION
When a member updates their personal information, their subscription forms are not automatically updated. This PR adds an after_update callback to clear subscription forms when relevant member attributes change. Fixes #492