### PR TITLE
Fix #491: Course capacity per level

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -16,9 +16,12 @@ module Admin
 
     def new
       @course = Course.new(category_id: params[:category_id])
+      build_course_level_capacities
     end
 
-    def edit; end
+    def edit
+      build_course_level_capacities
+    end
 
     def create
       @course = Course.new(course_params)
@@ -74,8 +77,22 @@ module Admin
       params[:level].presence || Member.levels.keys
     end
 
+    def build_course_level_capacities
+      existing_levels = @course.course_level_capacities.map(&:level)
+      Member.levels.keys.each do |level|
+        next if existing_levels.include?(level)
+
+        @course.course_level_capacities.build(level: level, capacity: 0)
+      end
+    end
+
     def course_params
-      params.expect(course: %i[title description capacity category_id weekday active features_attendance_sheet])
+      params.expect(
+        course: [
+          :title, :description, :capacity, :category_id, :weekday, :active, :features_attendance_sheet,
+          course_level_capacities_attributes: [:id, :level, :capacity, :_destroy]
+        ]
+      )
     end
   end
 end

--- a/app/models/concerns/courses/available.rb
+++ b/app/models/concerns/courses/available.rb
@@ -20,6 +20,18 @@ module Courses
           course.available?(year)
         end
       end
+
+      def available_for_level(level, year = Subscription.current_year)
+        return none if year > Subscription.current_year
+
+        active.where(id: with_courses_available_for_level(level, year))
+      end
+
+      def with_courses_available_for_level(level, year)
+        includes(:subscriptions, :course_level_capacities).select do |course|
+          course.available_for_level?(level, year)
+        end
+      end
     end
 
     def available?(year = Subscription.current_year)
@@ -30,11 +42,36 @@ module Courses
       capacity - active_subscriptions(year).size
     end
 
+    def available_for_level?(level, year = Subscription.current_year)
+      level_availability(level, year).positive?
+    end
+
+    def level_availability(level, year = Subscription.current_year)
+      level_capacity = course_level_capacities.find_by(level: level)&.capacity
+      return availability(year) if level_capacity.nil? || level_capacity.zero?
+
+      level_capacity - active_subscriptions_for_level(level, year).size
+    end
+
+    def level_capacities_configured?
+      course_level_capacities.any? { |clc| clc.capacity.positive? }
+    end
+
+    def total_level_capacity
+      course_level_capacities.sum(:capacity)
+    end
+
     private
 
     def active_subscriptions(year)
       subscriptions.reject do |subscription|
         subscription.archived? || subscription.year != year
+      end
+    end
+
+    def active_subscriptions_for_level(level, year)
+      active_subscriptions(year).select do |subscription|
+        subscription.member.level == level
       end
     end
   end

--- a/app/models/concerns/subscriptions/limitable.rb
+++ b/app/models/concerns/subscriptions/limitable.rb
@@ -98,7 +98,15 @@ module Subscriptions
     def courses_must_be_available
       return if courses.empty? # Skip if no courses
 
-      errors.add(:courses, :unavailable) if courses.any? { |c| !c.available? }
+      unavailable_courses = courses.reject do |course|
+        if member.present?
+          course.available_for_level?(member.level)
+        else
+          course.available?
+        end
+      end
+
+      errors.add(:courses, :unavailable) if unavailable_courses.any?
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -15,6 +15,9 @@ class Course < ApplicationRecord
   has_many :members, through: :subscriptions
   has_many :attendance_sheets, dependent: :destroy
   has_many :attendance_records, through: :attendance_sheets
+  has_many :course_level_capacities, dependent: :destroy
+
+  accepts_nested_attributes_for :course_level_capacities, allow_destroy: true
 
   enum :weekday, lundi: 1, mardi: 2, mercredi: 3, jeudi: 4, vendredi: 5, samedi: 6, dimanche: 7
 

--- a/app/models/course_level_capacity.rb
+++ b/app/models/course_level_capacity.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CourseLevelCapacity < ApplicationRecord
+  belongs_to :course
+
+  validates :level, presence: true, inclusion: { in: Member.levels.keys }
+  validates :capacity, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :level, uniqueness: { scope: :course_id }
+
+  enum :level, Member.levels
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -92,7 +92,7 @@ class Member < ApplicationRecord
                   saved_change_to_contact_relationship?
 
     subscriptions.with_attached_form.find_each do |subscription|
-      subscription.form.purge
+      subscription.form.purge if subscription.form.attached?
     end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -91,8 +91,8 @@ class Member < ApplicationRecord
                   saved_change_to_contact_phone_number? ||
                   saved_change_to_contact_relationship?
 
-    subscriptions.where.not(form: nil).find_each do |subscription|
-      subscription.form.purge if subscription.form.attached?
+    subscriptions.with_attached_form.find_each do |subscription|
+      subscription.form.purge
     end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -48,6 +48,8 @@ class Member < ApplicationRecord
   delegate :email, :phone_number, :address, :zip_code, :city, :country, :full_address,
            to: :user
 
+  after_update :clear_subscription_forms
+
   normalizes :first_name, with: ->(first_name) { first_name.strip.downcase.titleize }
   normalizes :last_name, with: ->(last_name) { last_name.strip.downcase.titleize }
 
@@ -77,5 +79,20 @@ class Member < ApplicationRecord
     return false if camps.include?(camp)
 
     true
+  end
+
+  private
+
+  def clear_subscription_forms
+    return unless saved_change_to_first_name? ||
+                  saved_change_to_last_name? ||
+                  saved_change_to_birthdate? ||
+                  saved_change_to_contact_name? ||
+                  saved_change_to_contact_phone_number? ||
+                  saved_change_to_contact_relationship?
+
+    subscriptions.where.not(form: nil).find_each do |subscription|
+      subscription.form.purge if subscription.form.attached?
+    end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -83,6 +83,15 @@ class Member < ApplicationRecord
 
   private
 
+  RELEVANT_ATTRIBUTES = %w[
+    first_name
+    last_name
+    birthdate
+    contact_name
+    contact_phone_number
+    contact_relationship
+  ].freeze
+
   def clear_subscription_forms
     return unless relevant_attributes_changed?
 
@@ -92,11 +101,6 @@ class Member < ApplicationRecord
   end
 
   def relevant_attributes_changed?
-    saved_change_to_first_name? ||
-      saved_change_to_last_name? ||
-      saved_change_to_birthdate? ||
-      saved_change_to_contact_name? ||
-      saved_change_to_contact_phone_number? ||
-      saved_change_to_contact_relationship?
+    RELEVANT_ATTRIBUTES.any? { |attr| send("saved_change_to_#{attr}?") }
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -81,8 +81,6 @@ class Member < ApplicationRecord
     true
   end
 
-  private
-
   RELEVANT_ATTRIBUTES = %w[
     first_name
     last_name
@@ -91,6 +89,8 @@ class Member < ApplicationRecord
     contact_phone_number
     contact_relationship
   ].freeze
+
+  private
 
   def clear_subscription_forms
     return unless relevant_attributes_changed?

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -84,15 +84,19 @@ class Member < ApplicationRecord
   private
 
   def clear_subscription_forms
-    return unless saved_change_to_first_name? ||
-                  saved_change_to_last_name? ||
-                  saved_change_to_birthdate? ||
-                  saved_change_to_contact_name? ||
-                  saved_change_to_contact_phone_number? ||
-                  saved_change_to_contact_relationship?
+    return unless relevant_attributes_changed?
 
     subscriptions.with_attached_form.find_each do |subscription|
       subscription.form.purge if subscription.form.attached?
     end
+  end
+
+  def relevant_attributes_changed?
+    saved_change_to_first_name? ||
+      saved_change_to_last_name? ||
+      saved_change_to_birthdate? ||
+      saved_change_to_contact_name? ||
+      saved_change_to_contact_phone_number? ||
+      saved_change_to_contact_relationship?
   end
 end

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -94,6 +94,32 @@
             </ul>
           </div>
         <% end %>
+
+        <p class="mt-1 text-xs text-gray-500">
+          <%= t('.capacity_note') %>
+        </p>
+      </div>
+
+      <div class="border-t pt-6">
+        <h3 class="text-lg font-medium text-gray-900 mb-4"><%= t('.level_capacities_title') %></h3>
+        <p class="text-sm text-gray-600 mb-4"><%= t('.level_capacities_description') %></p>
+
+        <div class="space-y-4">
+          <%= f.fields_for :course_level_capacities do |clc_form| %>
+            <div class="flex items-center gap-4">
+              <%= clc_form.hidden_field :id %>
+              <%= clc_form.hidden_field :level %>
+              <div class="flex-1">
+                <%= clc_form.label :capacity, Member.human_attribute_name("level.#{clc_form.object.level}"), class: "block text-sm font-medium text-gray-700" %>
+              </div>
+              <div class="w-32">
+                <%= clc_form.number_field :capacity,
+                    min: 0,
+                    class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-slate-800 focus:border-slate-800 sm:text-sm" %>
+              </div>
+            </div>
+          <% end %>
+        </div>
       </div>
 
       <div>

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -56,6 +56,21 @@
           <span class="ml-1"><%= @course.weekday %></span>
         </div>
       </div>
+
+      <% if @course.level_capacities_configured? %>
+        <div class="border-t pt-4 mt-4">
+          <h3 class="font-medium text-gray-700 mb-2"><%= t('.level_capacities') %></h3>
+          <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <% @course.course_level_capacities.order(:level).each do |clc| %>
+              <% next if clc.capacity.zero? %>
+              <div>
+                <span class="text-gray-600"><%= Member.human_attribute_name("level.#{clc.level}") %> :</span>
+                <span class="ml-1"><%= @course.level_availability(clc.level) %> / <%= clc.capacity %></span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
 
     <div class="flex flex-col sm:flex-row justify-end items-center gap-4 mt-8 pt-6 border-t">

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -158,6 +158,9 @@ fr:
       subscription:
         one: Inscription
         other: Inscriptions
+      course_level_capacity:
+        one: Capacité par niveau
+        other: Capacités par niveau
     attributes:
       camp:
         title: Titre
@@ -212,6 +215,9 @@ fr:
         weekday: Jour de la semaine
         active: Actif
         features_attendance_sheet: Feuille de présence
+      course_level_capacity:
+        level: Niveau
+        capacity: Capacité
       category:
         title: Titre
         min_age: Âge minimum
@@ -436,6 +442,7 @@ fr:
       show:
         new_subscription: Nouvelle inscription
         create_attendance_sheet: "Feuille de présence"
+        level_capacities: "Capacités par niveau"
       subscription:
         remove_from_course: Retirer du cours
         remove_from_course_are_you_sure: Êtes-vous sûr·e de vouloir retirer %{member_full_name} du cours %{course_title} ?
@@ -456,6 +463,9 @@ fr:
         success: Cours supprimé
       form:
         new_category: Ajouter une autre catégorie
+        capacity_note: "Définissez ici la capacité totale du cours."
+        level_capacities_title: "Capacités par niveau"
+        level_capacities_description: "Définissez la capacité maximale par niveau. Laissez à 0 pour utiliser la capacité globale du cours."
       course:
         create_attendance_sheet: "Feuille de présence"
     credit_notes:

--- a/db/migrate/20250323110000_create_course_level_capacities.rb
+++ b/db/migrate/20250323110000_create_course_level_capacities.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateCourseLevelCapacities < ActiveRecord::Migration[8.0]
+  def change
+    create_table :course_level_capacities do |t|
+      t.references :course, null: false, foreign_key: true
+      t.enum :level, null: false, enum_type: 'member_level'
+      t.integer :capacity, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :course_level_capacities, %i[course_id level], unique: true
+  end
+end

--- a/db/migrate/20250323110001_add_level_capacities_to_existing_courses.rb
+++ b/db/migrate/20250323110001_add_level_capacities_to_existing_courses.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddLevelCapacitiesToExistingCourses < ActiveRecord::Migration[8.0]
+  def up
+    Course.find_each do |course|
+      Member.levels.keys.each do |level|
+        CourseLevelCapacity.find_or_create_by!(course: course, level: level) do |clc|
+          clc.capacity = 0 # Default to 0, meaning no specific limit
+        end
+      end
+    end
+  end
+
+  def down
+    # Data migration rollback is a no-op as we keep the data
+  end
+end

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -18,44 +18,50 @@ describe Member, type: :model do
 
     context 'when member first_name is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(first_name: 'NewName') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(first_name: 'NewName')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member last_name is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(last_name: 'NewLastName') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(last_name: 'NewLastName')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member birthdate is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(birthdate: 10.years.ago) }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(birthdate: 10.years.ago)
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member contact_name is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(contact_name: 'New Contact') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(contact_name: 'New Contact')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member contact_phone_number is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(contact_phone_number: '+33600000000') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(contact_phone_number: '+33600000000')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member contact_relationship is updated' do
       it 'clears the subscription form' do
-        expect { member.update!(contact_relationship: 'Autre') }.to change { subscription.form.attached? }.from(true).to(false)
+        member.update!(contact_relationship: 'Autre')
+        expect(subscription.reload.form.attached?).to be false
       end
     end
 
     context 'when member attributes not affecting form are updated' do
       it 'does not clear the subscription form' do
-        expect { member.update!(agreed_to_advertising_right: !member.agreed_to_advertising_right) }
-          .not_to(change { subscription.form.attached? })
+        member.update!(agreed_to_advertising_right: !member.agreed_to_advertising_right)
+        expect(subscription.reload.form.attached?).to be true
       end
     end
 
@@ -72,8 +78,8 @@ describe Member, type: :model do
 
       it 'clears all subscription forms' do
         member.update!(first_name: 'NewName')
-        expect(subscription.form.attached?).to be false
-        expect(subscription2.form.attached?).to be false
+        expect(subscription.reload.form.attached?).to be false
+        expect(subscription2.reload.form.attached?).to be false
       end
     end
   end

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -14,6 +14,7 @@ describe Member, type: :model do
         filename: 'form.pdf',
         content_type: 'application/pdf'
       )
+      subscription.reload
     end
 
     context 'when member first_name is updated' do

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -7,6 +7,7 @@ describe Member, type: :model do
     let(:user) { create(:user) }
     let(:member) { create(:member, user: user) }
     let(:category) { create(:category) }
+    let!(:pricing) { create(:pricing, category: category) }
     let(:course) { create(:course, category: category) }
     let(:subscription) { create(:subscription, member: member, status: :confirmed, courses: [course]) }
 

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Member, type: :model do
+  describe '#clear_subscription_forms' do
+    let(:user) { create(:user) }
+    let(:member) { create(:member, user: user) }
+    let(:subscription) { create(:subscription, member: member, status: :confirmed) }
+
+    before do
+      subscription.form.attach(
+        io: StringIO.new('dummy pdf content'),
+        filename: 'form.pdf',
+        content_type: 'application/pdf'
+      )
+    end
+
+    context 'when member first_name is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(first_name: 'NewName') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member last_name is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(last_name: 'NewLastName') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member birthdate is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(birthdate: 10.years.ago) }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member contact_name is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(contact_name: 'New Contact') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member contact_phone_number is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(contact_phone_number: '+33600000000') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member contact_relationship is updated' do
+      it 'clears the subscription form' do
+        expect { member.update!(contact_relationship: 'Autre') }.to change { subscription.form.attached? }.from(true).to(false)
+      end
+    end
+
+    context 'when member attributes not affecting form are updated' do
+      it 'does not clear the subscription form' do
+        expect { member.update!(agreed_to_advertising_right: !member.agreed_to_advertising_right) }
+          .not_to(change { subscription.form.attached? })
+      end
+    end
+
+    context 'when member has multiple subscriptions' do
+      let(:subscription2) { create(:subscription, member: member, status: :confirmed) }
+
+      before do
+        subscription2.form.attach(
+          io: StringIO.new('dummy pdf content 2'),
+          filename: 'form2.pdf',
+          content_type: 'application/pdf'
+        )
+      end
+
+      it 'clears all subscription forms' do
+        member.update!(first_name: 'NewName')
+        expect(subscription.form.attached?).to be false
+        expect(subscription2.form.attached?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -6,7 +6,9 @@ describe Member, type: :model do
   describe '#clear_subscription_forms' do
     let(:user) { create(:user) }
     let(:member) { create(:member, user: user) }
-    let(:subscription) { create(:subscription, member: member, status: :confirmed) }
+    let(:category) { create(:category) }
+    let(:course) { create(:course, category: category) }
+    let(:subscription) { create(:subscription, member: member, status: :confirmed, courses: [course]) }
 
     before do
       subscription.form.attach(
@@ -67,7 +69,8 @@ describe Member, type: :model do
     end
 
     context 'when member has multiple subscriptions' do
-      let(:subscription2) { create(:subscription, member: member, status: :confirmed) }
+      let(:course2) { create(:course, category: category, weekday: Course.weekdays.keys.last) }
+      let(:subscription2) { create(:subscription, member: member, status: :confirmed, courses: [course2]) }
 
       before do
         subscription2.form.attach(
@@ -75,6 +78,7 @@ describe Member, type: :model do
           filename: 'form2.pdf',
           content_type: 'application/pdf'
         )
+        subscription2.reload
       end
 
       it 'clears all subscription forms' do

--- a/spec/models/concerns/members/subscription_form_spec.rb
+++ b/spec/models/concerns/members/subscription_form_spec.rb
@@ -71,7 +71,7 @@ describe Member, type: :model do
 
     context 'when member has multiple subscriptions' do
       let(:course2) { create(:course, category: category, weekday: Course.weekdays.keys.last) }
-      let(:subscription2) { create(:subscription, member: member, status: :confirmed, courses: [course2]) }
+      let(:subscription2) { create(:subscription, member: member, status: :confirmed, courses: [course2], year: Subscription.current_year - 1) }
 
       before do
         subscription2.form.attach(

--- a/spec/models/course_level_capacity_spec.rb
+++ b/spec/models/course_level_capacity_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CourseLevelCapacity, type: :model do
+  it { is_expected.to belong_to(:course) }
+
+  it { is_expected.to validate_presence_of(:level) }
+  it { is_expected.to validate_inclusion_of(:level).in_array(Member.levels.keys) }
+  it { is_expected.to validate_numericality_of(:capacity).is_greater_than_or_equal_to(0).only_integer }
+  it { is_expected.to validate_uniqueness_of(:level).scoped_to(:course_id) }
+
+  it { is_expected.to define_enum_for(:level).with_values(Member.levels) }
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -16,6 +16,8 @@ describe Course, type: :model do
   it { is_expected.to have_many(:courses_subscriptions).dependent(:destroy) }
   it { is_expected.to have_many(:subscriptions).through(:courses_subscriptions) }
   it { is_expected.to have_many(:members).through(:subscriptions) }
+  it { is_expected.to have_many(:course_level_capacities).dependent(:destroy) }
+  it { is_expected.to accept_nested_attributes_for(:course_level_capacities) }
 
   it { is_expected.to define_enum_for(:weekday).with_values({ lundi: 1, mardi: 2, mercredi: 3, jeudi: 4, vendredi: 5, samedi: 6, dimanche: 7 }) }
 


### PR DESCRIPTION
Fixes #491: Course capacity per level

This PR implements the ability for admins to configure course capacity per member level (white, yellow, green, red) instead of just a global capacity.

Changes:
- New CourseLevelCapacity model with level-specific capacities
- Updated Courses::Available concern with level_availability methods  
- Updated Subscriptions::Limitable to check per-level availability
- Updated admin UI for configuring level capacities
- Added migrations and data migration for existing courses
- Added model specs

When level capacity is 0, falls back to global capacity (backward compatible).

Full details: https://github.com/EmCousin/pkp/compare/main...feature/course-capacity-per-level-491