### PR TITLE
Implement coach assignments feature (Issue #489)

### DIFF
--- a/app/controllers/admin/assignments_controller.rb
+++ b/app/controllers/admin/assignments_controller.rb
@@ -12,22 +12,22 @@ module Admin
     def create
       @assignment = Assignment.new(assignment_params)
       if @assignment.save
-        redirect_to admin_assignments_path(year: @assignment.year), notice: t(".success")
+        redirect_to admin_assignments_path(year: @assignment.year), notice: t('.success')
       else
-        redirect_to admin_assignments_path(year: @assignment.year), alert: t(".failure")
+        redirect_to admin_assignments_path(year: @assignment.year), alert: t('.failure')
       end
     end
 
     def destroy
       @assignment = Assignment.includes(:coach, :course).find(params[:id])
       @assignment.destroy
-      redirect_to admin_assignments_path(year: @assignment.year), notice: t(".success")
+      redirect_to admin_assignments_path(year: @assignment.year), notice: t('.success')
     end
 
     private
 
     def assignment_params
-      params.expect(assignment: [:coach_id, :course_id, :level, :year])
+      params.expect(assignment: %i[coach_id course_id level year])
     end
   end
 end

--- a/app/controllers/admin/assignments_controller.rb
+++ b/app/controllers/admin/assignments_controller.rb
@@ -19,7 +19,7 @@ module Admin
     end
 
     def destroy
-      @assignment = Assignment.find(params[:id])
+      @assignment = Assignment.includes(:coach, :course).find(params[:id])
       @assignment.destroy
       redirect_to admin_assignments_path(year: @assignment.year), notice: t(".success")
     end

--- a/app/controllers/admin/assignments_controller.rb
+++ b/app/controllers/admin/assignments_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Admin
+  class AssignmentsController < BaseController
+    def index
+      @year = params[:year] || Time.current.year
+      @coaches = Member.coaches.order(:last_name, :first_name)
+      @courses = Course.includes(:category).where(active: true).order(:title)
+      @assignments = Assignment.includes(:coach, :course).where(year: @year)
+    end
+
+    def create
+      @assignment = Assignment.new(assignment_params)
+      if @assignment.save
+        redirect_to admin_assignments_path(year: @assignment.year), notice: t(".success")
+      else
+        redirect_to admin_assignments_path(year: @assignment.year), alert: t(".failure")
+      end
+    end
+
+    def destroy
+      @assignment = Assignment.find(params[:id])
+      @assignment.destroy
+      redirect_to admin_assignments_path(year: @assignment.year), notice: t(".success")
+    end
+
+    private
+
+    def assignment_params
+      params.expect(assignment: [:coach_id, :course_id, :level, :year])
+    end
+  end
+end

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -61,9 +61,9 @@ module Admin
       params.expect(
         member: [:level, :first_name, :last_name, :birthdate,
                  :contact_name, :contact_phone_number, :contact_relationship,
-                 :avatar,
+                 :avatar, :coach,
                  :agreed_to_advertising_right,
-                 { user_attributes: %i[id email password address zip_code city country phone_number admin coach] }]
+                 { user_attributes: %i[id email password address zip_code city country phone_number admin] }]
       )
     end
 

--- a/app/controllers/dashboard/assignments_controller.rb
+++ b/app/controllers/dashboard/assignments_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Dashboard
+  class AssignmentsController < DashboardController
+    def show
+      @year = Time.current.year
+      @courses = Course.includes(:category).where(active: true).order(:title)
+      @assignments = Assignment.includes(:coach, :course).where(year: @year)
+    end
+  end
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Assignment < ApplicationRecord
+  belongs_to :course
+  belongs_to :coach, -> { where(coach: true) }, class_name: "Member"
+
+  enum :level, white: "white", yellow: "yellow", green: "green", red: "red"
+
+  validates :coach, :course, :level, :year, presence: true
+  validates :year, numericality: { only_integer: true }
+  validates :coach_id, uniqueness: { scope: %i[course_id level year] }
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -2,11 +2,11 @@
 
 class Assignment < ApplicationRecord
   belongs_to :course
-  belongs_to :coach, -> { where(coach: true) }, class_name: "Member"
+  belongs_to :coach, -> { where(coach: true) }, class_name: 'Member', inverse_of: :assignments
 
-  enum :level, white: "white", yellow: "yellow", green: "green", red: "red"
+  enum :level, white: 'white', yellow: 'yellow', green: 'green', red: 'red'
 
-  validates :coach, :course, :level, :year, presence: true
+  validates :level, :year, presence: true
   validates :year, numericality: { only_integer: true }
   validates :coach_id, uniqueness: { scope: %i[course_id level year] }
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -15,6 +15,8 @@ class Course < ApplicationRecord
   has_many :members, through: :subscriptions
   has_many :attendance_sheets, dependent: :destroy
   has_many :attendance_records, through: :attendance_sheets
+  has_many :assignments, dependent: :destroy
+  has_many :coaches, through: :assignments, source: :coach
 
   enum :weekday, lundi: 1, mardi: 2, mercredi: 3, jeudi: 4, vendredi: 5, samedi: 6, dimanche: 7
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -34,7 +34,7 @@ class Member < ApplicationRecord
   has_many :camps, through: :subscriptions
   has_many :attendance_records, dependent: :destroy
   has_many :attendance_sheets, through: :attendance_records
-  has_many :assignments, foreign_key: :coach_id, dependent: :destroy
+  has_many :assignments, foreign_key: :coach_id, dependent: :destroy, inverse_of: :coach
   has_many :assigned_courses, through: :assignments, source: :course
 
   has_one_attached :avatar do |attachable|

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -34,6 +34,8 @@ class Member < ApplicationRecord
   has_many :camps, through: :subscriptions
   has_many :attendance_records, dependent: :destroy
   has_many :attendance_sheets, through: :attendance_records
+  has_many :assignments, foreign_key: :coach_id, dependent: :destroy
+  has_many :assigned_courses, through: :assignments, source: :course
 
   has_one_attached :avatar do |attachable|
     attachable.variant :mini, resize: '80x80'
@@ -51,6 +53,12 @@ class Member < ApplicationRecord
 
   normalizes :first_name, with: ->(first_name) { first_name.strip.downcase.titleize }
   normalizes :last_name, with: ->(last_name) { last_name.strip.downcase.titleize }
+
+  scope :coaches, -> { where(coach: true) }
+
+  def coach?
+    coach
+  end
 
   def full_name
     "#{first_name.strip.downcase.titleize} #{last_name.strip.downcase.titleize}"

--- a/app/views/admin/assignments/index.html.erb
+++ b/app/views/admin/assignments/index.html.erb
@@ -1,0 +1,130 @@
+<%# frozen_string_literal: true %>
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold text-gray-900"><%= t('.title') %></h1>
+    
+    <div class="mt-4">
+      <%= form_with url: admin_assignments_path, method: :get, class: "flex items-center gap-4" do |form| %>
+        <%= form.select :year, 
+            (Time.current.year - 2..Time.current.year + 1).to_a.reverse,
+            { selected: @year },
+            { class: "block w-32 rounded-md border-gray-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 sm:text-sm",
+              onchange: "this.form.submit()" } %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mb-6">
+    <h2 class="text-lg font-medium text-gray-900 mb-3"><%= t('.coaches') %></h2>
+    <div class="flex flex-wrap gap-2" id="coaches-list">
+      <% @coaches.each do |coach| %>
+        <div class="coach-pill inline-flex items-center gap-2 px-3 py-1.5 bg-blue-100 text-blue-800 rounded-full text-sm font-medium cursor-move"
+             draggable="true"
+             data-coach-id="<%= coach.id %>"
+             data-coach-name="<%= coach.full_name %>">
+          <%= coach.full_name %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="bg-white shadow-sm rounded-lg overflow-hidden">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <%= t('.course') %>
+          </th>
+          <% Member.levels.keys.each do |level| %>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <%= Member.human_attribute_name(level) %>
+            </th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-200">
+        <% @courses.each do |course| %>
+          <tr>
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+              <%= course.title %>
+              <span class="text-gray-500">(<%= course.category.title %>)</span>
+            </td>
+            <% Member.levels.keys.each do |level| %>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <% assignment = @assignments.find { |a| a.course_id == course.id && a.level == level } %>
+                <div class="assignment-cell min-h-[40px] p-2 border-2 border-dashed border-gray-300 rounded-lg transition-colors"
+                     data-course-id="<%= course.id %>"
+                     data-level="<%= level %>">
+                  <% if assignment %>
+                    <div class="assignment-pill inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-800 rounded text-sm">
+                      <%= assignment.coach.full_name %>
+                      <%= button_to admin_assignment_path(assignment), 
+                          method: :delete,
+                          class: "ml-1 text-green-600 hover:text-green-900",
+                          form: { data: { turbo_confirm: t('.confirm_remove') } } do %>
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%= form_with url: admin_assignments_path, id: "assignment-form", class: "hidden" do |form| %>
+  <%= form.hidden_field :coach_id, id: "assignment_coach_id" %>
+  <%= form.hidden_field :course_id, id: "assignment_course_id" %>
+  <%= form.hidden_field :level, id: "assignment_level" %>
+  <%= form.hidden_field :year, value: @year %>
+<% end %>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const coaches = document.querySelectorAll('.coach-pill');
+  const cells = document.querySelectorAll('.assignment-cell');
+  let draggedCoachId = null;
+  let draggedCoachName = null;
+
+  coaches.forEach(coach => {
+    coach.addEventListener('dragstart', function(e) {
+      draggedCoachId = this.dataset.coachId;
+      draggedCoachName = this.dataset.coachName;
+      e.dataTransfer.effectAllowed = 'copy';
+    });
+  });
+
+  cells.forEach(cell => {
+    cell.addEventListener('dragover', function(e) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      this.classList.add('border-blue-400', 'bg-blue-50');
+    });
+
+    cell.addEventListener('dragleave', function(e) {
+      this.classList.remove('border-blue-400', 'bg-blue-50');
+    });
+
+    cell.addEventListener('drop', function(e) {
+      e.preventDefault();
+      this.classList.remove('border-blue-400', 'bg-blue-50');
+      
+      const courseId = this.dataset.courseId;
+      const level = this.dataset.level;
+      
+      document.getElementById('assignment_coach_id').value = draggedCoachId;
+      document.getElementById('assignment_course_id').value = courseId;
+      document.getElementById('assignment_level').value = level;
+      
+      document.getElementById('assignment-form').submit();
+    });
+  });
+});
+</script>

--- a/app/views/admin/members/_form.html.erb
+++ b/app/views/admin/members/_form.html.erb
@@ -119,13 +119,14 @@
           </div>
         </div>
 
-        <div>
-          <div class="flex items-center">
-            <%= user_form.check_box :coach, class: "h-4 w-4 text-slate-800 border-gray-300 rounded focus:ring-slate-800" %>
-            <%= user_form.label :coach, class: "ml-2 block text-sm text-gray-700" %>
-          </div>
-        </div>
       <% end %>
+
+      <div>
+        <div class="flex items-center">
+          <%= form.check_box :coach, class: "h-4 w-4 text-slate-800 border-gray-300 rounded focus:ring-slate-800" %>
+          <%= form.label :coach, class: "ml-2 block text-sm text-gray-700" %>
+        </div>
+      </div>
 
       <div>
         <%= form.label :contact_name, class: "block text-sm font-medium text-gray-700 mb-1" %>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -28,7 +28,7 @@
                     <%= t('.admin_label') %>
                   </span>
                 <% end %>
-                <% if @member.user.coach? %>
+                <% if @member.coach? %>
                   <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
                     <%= t('.coach_label') %>
                   </span>
@@ -152,6 +152,25 @@
       </div>
     </div>
   </div>
+
+  <% if @member.coach? %>
+    <div class="mt-6">
+      <h3 class="text-lg font-medium text-gray-900 mb-4"><%= t('.assignments') %></h3>
+      <% @member.assignments.includes(:course).group_by(&:year).sort.reverse_each do |year, assignments| %>
+        <div class="mb-4">
+          <h4 class="text-base font-medium text-gray-700 mb-2"><%= year %></h4>
+          <div class="space-y-2">
+            <% assignments.each do |assignment| %>
+              <div class="flex items-center gap-2">
+                <%= tag.span class: "inline-block w-3 h-3 rounded border border-gray-300", style: "background-color: #{assignment.level};" %>
+                <span><%= assignment.course.title %> (<%= t("activerecord.enums.assignment.level.#{assignment.level}") %>)</span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
   <div class="flex flex-col sm:flex-row gap-3 pt-6 mt-6 border-t border-gray-200">
     <%= link_to t('defaults.back'),

--- a/app/views/dashboard/assignments/show.html.erb
+++ b/app/views/dashboard/assignments/show.html.erb
@@ -1,0 +1,47 @@
+<%# frozen_string_literal: true %>
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold text-gray-900"><%= t('.title') %></h1>
+    <p class="mt-2 text-gray-600"><%= @year %></p>
+  </div>
+
+  <div class="bg-white shadow-sm rounded-lg overflow-hidden">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <%= t('.course') %>
+          </th>
+          <% Member.levels.keys.each do |level| %>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <%= Member.human_attribute_name(level) %>
+            </th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-200">
+        <% @courses.each do |course| %>
+          <tr>
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+              <%= course.title %>
+              <span class="text-gray-500">(<%= course.category.title %>)</span>
+            </td>
+            <% Member.levels.keys.each do |level| %>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <% assignment = @assignments.find { |a| a.course_id == course.id && a.level == level } %>
+                <% if assignment %>
+                  <span class="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-800 rounded text-sm">
+                    <%= assignment.coach.full_name %>
+                  </span>
+                <% else %>
+                  <span class="text-gray-400">—</span>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -23,6 +23,7 @@
                     <%= link_to t('.members'), %i[admin members], class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
                     <%= link_to t('.categories'), %i[admin categories], class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
                     <%= link_to t('.courses'), %i[admin courses], class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+                    <%= link_to t('.assignments'), %i[admin assignments], class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
                     <%= link_to t('.camps'), %i[admin camps], class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
                     <%= link_to t('.subscriptions'), %i[admin subscriptions], class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
                   </div>
@@ -87,6 +88,7 @@
                       <%= link_to t('.members'), %i[admin members], class: "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium" %>
                       <%= link_to t('.categories'), %i[admin categories], class: "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium" %>
                       <%= link_to t('.courses'), %i[admin courses], class: "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium" %>
+                      <%= link_to t('.assignments'), %i[admin assignments], class: "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium" %>
                       <%= link_to t('.camps'), %i[admin camps], class: "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium" %>
                       <%= link_to t('.subscriptions'), %i[admin subscriptions], class: "text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium" %>
                     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     get '/', to: redirect('/admin/members')
     concerns :courses_manageable
 
+    resources :assignments, only: [:index, :create, :destroy]
     resources :categories, only: [:index, :show, :new, :create, :edit, :update, :destroy]
     resources :members do
       resource :level, only: [:update]
@@ -119,6 +120,7 @@ Rails.application.routes.draw do
   end
 
   namespace :dashboard do
+    resource :assignments, only: [:show]
     resources :members, only: [:new, :create, :edit, :update]
     resources :subscriptions, only: [:show, :new, :create] do
       resource :term, as: :terms, only: [:edit, :update]

--- a/db/migrate/20260323000001_add_coach_to_members.rb
+++ b/db/migrate/20260323000001_add_coach_to_members.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCoachToMembers < ActiveRecord::Migration[7.2]
+class AddCoachToMembers < ActiveRecord::Migration[8.0]
   def change
     add_column :members, :coach, :boolean, default: false, null: false
   end

--- a/db/migrate/20260323000001_add_coach_to_members.rb
+++ b/db/migrate/20260323000001_add_coach_to_members.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCoachToMembers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :members, :coach, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260323000002_create_assignments.rb
+++ b/db/migrate/20260323000002_create_assignments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateAssignments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :assignments do |t|
+      t.references :coach, null: false, foreign_key: { to_table: :members }
+      t.references :course, null: false, foreign_key: true
+      t.enum :level, enum_type: :member_level, null: false
+      t.integer :year, null: false
+      t.timestamps
+    end
+
+    add_index :assignments, %i[coach_id course_id level year], unique: true
+  end
+end

--- a/db/migrate/20260323000002_create_assignments.rb
+++ b/db/migrate/20260323000002_create_assignments.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAssignments < ActiveRecord::Migration[7.2]
+class CreateAssignments < ActiveRecord::Migration[8.0]
   def change
     create_table :assignments do |t|
       t.references :coach, null: false, foreign_key: { to_table: :members }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_12_123801) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_23_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -150,6 +150,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_12_123801) do
     t.index ["subscription_id"], name: "index_courses_subscriptions_on_subscription_id"
   end
 
+  create_table "assignments", force: :cascade do |t|
+    t.bigint "coach_id", null: false
+    t.bigint "course_id", null: false
+    t.enum "level", null: false, enum_type: "member_level"
+    t.integer "year", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coach_id", "course_id", "level", "year"], name: "index_assignments_on_coach_id_and_course_id_and_level_and_year", unique: true
+    t.index ["coach_id"], name: "index_assignments_on_coach_id"
+    t.index ["course_id"], name: "index_assignments_on_course_id"
+  end
+
   create_table "members", force: :cascade do |t|
     t.bigint "user_id"
     t.string "first_name", null: false
@@ -162,6 +174,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_12_123801) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.enum "level", default: "white", null: false, enum_type: "member_level"
+    t.boolean "coach", default: false, null: false
     t.index ["first_name", "last_name"], name: "index_members_on_first_name_and_last_name"
     t.index ["level"], name: "index_members_on_level"
     t.index ["user_id"], name: "index_members_on_user_id"
@@ -246,4 +259,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_12_123801) do
   add_foreign_key "pricings", "categories"
   add_foreign_key "subscriptions", "members"
   add_foreign_key "subscriptions", "subscriptions", column: "parent_subscription_id"
+  add_foreign_key "assignments", "courses"
+  add_foreign_key "assignments", "members", column: "coach_id"
 end

--- a/spec/factories/assignments.rb
+++ b/spec/factories/assignments.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :assignment do
+    association :coach, factory: %i[member coach]
+    association :course
+    level { :white }
+    year { Time.current.year }
+  end
+end

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -14,4 +14,8 @@ FactoryBot.define do
   trait :minor do
     birthdate { 10.years.ago }
   end
+
+  trait :coach do
+    coach { true }
+  end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Assignment, type: :model do
+  subject { assignment }
+
+  let(:course) { create :course }
+  let(:coach) { create :member, coach: true }
+  let(:assignment) { build :assignment, course: course, coach: coach }
+
+  it { is_expected.to belong_to(:course) }
+  it { is_expected.to belong_to(:coach).class_name('Member') }
+
+  it { is_expected.to validate_presence_of(:coach) }
+  it { is_expected.to validate_presence_of(:course) }
+  it { is_expected.to validate_presence_of(:level) }
+  it { is_expected.to validate_presence_of(:year) }
+
+  it { is_expected.to validate_numericality_of(:year).only_integer }
+
+  describe 'uniqueness validation' do
+    subject { described_class.create(course: course, coach: coach, level: :white, year: 2024) }
+
+    it { is_expected.to validate_uniqueness_of(:coach_id).scoped_to(%i[course_id level year]) }
+  end
+
+  describe '#level enum' do
+    it 'defines the correct levels' do
+      expect(described_class.levels.keys).to contain_exactly('white', 'yellow', 'green', 'red')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR implements **Issue #489: Assign a coach to a level per course per year**.

## Changes Made

### Database
- Migration: Add `coach` boolean column to `members` table
- Migration: Create `assignments` table with:
  - `coach_id` (foreign key to `members`)
  - `course_id` (foreign key to `courses`)
  - `level` enum (white/yellow/green/red)
  - `year` integer
  - Unique index on `[coach_id, course_id, level, year]`

### Models
- **Assignment**: Validations for presence and uniqueness
- **Member**: Added `coaches` scope, `coach?` method, and associations to `assignments`
- **Course**: Added associations to `assignments` and `coaches`

### Admin Panel
- Coach checkbox added to member form
- Coach status and assignments displayed on member show page
- New "Assignments" menu item (will translate to "Répartition des coachs")
- Drag-and-drop assignment UI:
  - List of coaches at top
  - Table with courses as rows, levels as columns
  - Drag coaches to cells to assign
  - Click X to remove assignments
  - Year selector dropdown

### Dashboard
- Readonly view of assignments for current year
- Accessible to authenticated users

### Tests
- Added `Assignment` model spec
- Updated `Member` factory with `:coach` trait
- Added `Assignment` factory

Fixes #489