### PR TITLE
Fix birthdate validation rejecting valid 6-year-olds

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -42,7 +42,7 @@ class Member < ApplicationRecord
   enum :level, white: 'white', yellow: 'yellow', green: 'green', red: 'red'
 
   validates :first_name, :last_name, :contact_name, :avatar, presence: true
-  validates :birthdate, presence: true, inclusion: { in: (99.years.ago)..(6.years.ago), on: :create }
+  validates :birthdate, presence: true, inclusion: { in: ->(_) { 99.years.ago.to_date..6.years.ago.to_date } }, on: :create
   validates :contact_phone_number, presence: true, phone: true
   validates :contact_relationship, presence: true, inclusion: { in: CONTACTS }
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -42,7 +42,8 @@ class Member < ApplicationRecord
   enum :level, white: 'white', yellow: 'yellow', green: 'green', red: 'red'
 
   validates :first_name, :last_name, :contact_name, :avatar, presence: true
-  validates :birthdate, presence: true, inclusion: { in: ->(_) { 99.years.ago.to_date..6.years.ago.to_date } }, on: :create
+  validates :birthdate, presence: true
+  validates :birthdate, inclusion: { in: ->(_) { 99.years.ago.to_date..6.years.ago.to_date } }, on: :create, allow_blank: true
   validates :contact_phone_number, presence: true, phone: true
   validates :contact_relationship, presence: true, inclusion: { in: CONTACTS }
 


### PR DESCRIPTION
## Problem

When a parent tries to register a child born on 14/03/2020, the form rejects the date with \"2020-03-14 n'est pas une date valide\" — even though the child is 6 years old.

## Root cause

`member.rb:45` had:
```ruby
validates :birthdate, presence: true, inclusion: { in: (99.years.ago)..(6.years.ago), on: :create }
```

The range `(99.years.ago)..(6.years.ago)` is evaluated **once at class load time**, not per request. If the server was last restarted before March 14, 2026 (the child's 6th birthday), `6.years.ago` at boot was a date prior to March 14, 2020 — making that birthday appear too recent and thus invalid.

## Fix

Use a lambda so the range is recomputed on every validation:
```ruby
validates :birthdate, presence: true, inclusion: { in: ->(_) { 99.years.ago.to_date..6.years.ago.to_date } }, on: :create
```

Also fixes `on: :create` being inside the `inclusion:` hash (where it's unrecognized) instead of at the top level of `validates`.

## Deploy note

The fix takes effect immediately on next deploy — no server restart or data migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)